### PR TITLE
Auto-detect default interface

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,8 @@
 set -euo pipefail
 
 # --- Standard-Parameter (anpassbar im Menü) ---
-HOST_IFACE="eth0"
+# Netzwerk-Interface automatisch ermitteln (Standard-Route)
+HOST_IFACE="$(ip -4 route show default | awk '/default/ {print $5; exit}')"
 WG_IFACE="wg0"
 WG_IPV4_BASE="10.66.66"
 WG_IPV6_BASE="fd00:dead:beef"


### PR DESCRIPTION
## Summary
- detect the default network interface dynamically in `install.sh`

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68605a8ff8d48322a305a40052ce5f80