### PR TITLE
Auto-detect default interface

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,8 @@
 set -euo pipefail
 
 # --- Standard-Parameter (anpassbar im Menü) ---
-HOST_IFACE="eth0"
+# Netzwerk-Interface automatisch ermitteln (Standard-Route)
+HOST_IFACE="$(ip -4 route show default | awk '/default/ {print $5; exit}')"
 WG_IFACE="wg0"
 WG_IPV4_BASE="10.66.66"
 WG_IPV6_BASE="fd00:dead:beef"
@@ -31,8 +32,9 @@ exec > >(tee -a "$LOGFILE") 2>&1
 
 # --- Paketinstallation ---
 install_packages() {
-  apt update
-  DEBIAN_FRONTEND=noninteractive apt install -y wireguard nftables unbound adguardhome tc iproute2 qrencode nginx curl
+  apt-get update
+  DEBIAN_FRONTEND=noninteractive apt-get install -y wireguard nftables unbound tc iproute2 qrencode nginx curl
+  install_adguard_home
   mkdir -p "$PEERS_DIR" "$BACKUP_DIR" "$LANDING_DIR" "/etc/nftables"
   touch "$MANUAL_BLACKLIST_FILE" "$GEO_BLACKLIST_FILE" "$PEERS_DIR/metadata.csv"
   # IP-Forwarding dauerhaft aktivieren
@@ -73,6 +75,16 @@ server:
 EOF
   systemctl enable unbound
   systemctl restart unbound
+}
+
+# --- AdGuard Home Installation ---
+install_adguard_home() {
+  [[ -x /usr/bin/AdGuardHome ]] && return
+  tmpdir=$(mktemp -d)
+  curl -L https://static.adguard.com/adguardhome/release/AdGuardHome_linux_amd64.tar.gz -o "$tmpdir/adguard.tar.gz"
+  tar -xzf "$tmpdir/adguard.tar.gz" -C "$tmpdir"
+  "$tmpdir/AdGuardHome/AdGuardHome" -s install
+  rm -rf "$tmpdir"
 }
 
 # --- AdGuard Home konfigurieren ---


### PR DESCRIPTION
## Summary
- detect the default network interface dynamically in `install.sh`
- replace apt calls with `apt-get`
- install AdGuard Home from upstream binary instead of expecting a deb package

## Testing
- `bash -n install.sh`
- `shellcheck install.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68605a8ff8d48322a305a40052ce5f80