### PR TITLE
Fix configure_tc script creation

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -204,7 +204,7 @@ configure_tc() {
       fi
     done
   fi
-  cat > /usr/local/bin/configure_tc.sh <<'EOF'
+  cat > /usr/local/bin/configure_tc.sh <<EOF
 #!/usr/bin/env bash
 $(declare -f configure_tc)
 configure_tc


### PR DESCRIPTION
## Summary
- allow variable expansion when writing configure_tc.sh

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68610bce9d6c8322848b80e0e8aee109