### PR TITLE
Install AdGuard via official script

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Wir verfolgen folgende Hauptziele:
 ## Bereits umgesetzt
 
 * Vollständiges Bash‑Skript (`install.sh`) mit allen oben genannten Funktionen
-* Einbinden von AdGuard Home per offiziellem Service-Installer
+* Einbinden von AdGuard Home per offiziellem Service-Installer (Installation unter `/opt/AdGuardHome`)
 * Automatische Installation aller benötigten Pakete, inklusive `iptables`
 * Vollständige nftables-Konfiguration mit Syntax‑Checks und Service–Integration
 * Interaktives Menü mit Punkten für Installation, Peer-Erstellung, Backup/Restore, Blacklist‑Editing, Reload

--- a/install.sh
+++ b/install.sh
@@ -48,15 +48,10 @@ install_packages() {
     wireguard nftables unbound iproute2 qrencode nginx curl wget iptables
 
   # AdGuard Home herunterladen & installieren
-  ADGUARD_DIR="/etc/adguard/AdGuardHome"
+  ADGUARD_DIR="/opt/AdGuardHome"
   [[ -x "$ADGUARD_DIR/AdGuardHome" ]] && return
-  tmpdir=$(mktemp -d)
-  curl -L https://static.adguard.com/adguardhome/release/AdGuardHome_linux_amd64.tar.gz -o "$tmpdir/adguard.tar.gz"
-  tar -xzf "$tmpdir/adguard.tar.gz" -C "$tmpdir"
-  mkdir -p /etc/adguard
-  mv "$tmpdir/AdGuardHome" "$ADGUARD_DIR"
-  "$ADGUARD_DIR/AdGuardHome" -s install
-  rm -rf "$tmpdir"
+  curl -s -S -L https://raw.githubusercontent.com/AdguardTeam/AdGuardHome/master/scripts/install.sh \
+    | sh -s -- -v
   safe_systemctl enable AdGuardHome
   safe_systemctl start AdGuardHome
 
@@ -110,7 +105,7 @@ configure_adguard() {
   sed -i "s|^bind_port:.*|bind_port: ${ADGUARD_UI_PORT}|" /opt/AdGuardHome/AdGuardHome.yaml
   # DNS-Server
   sed -i '/^dns:/,/^  upstream_dns:/d' /opt/AdGuardHome/AdGuardHome.yaml
-  cat >> /etc/adguard/AdGuardHome/AdGuardHome.yaml <<EOF
+  cat >> /opt/AdGuardHome/AdGuardHome.yaml <<EOF
 dns:
   bind_hosts:
     - ${VPN_IPV4}


### PR DESCRIPTION
## Summary
- use AdGuard's official installer script in `install_packages`
- note default path in the README

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_e_686117fbf6988322bd3c90c351cabb92