### PR TITLE
Handle existing wg interface during reinstall

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,13 @@ install_packages() {
 
 # --- WireGuard konfigurieren ---
 configure_wireguard() {
+  # Remove existing interface if present to allow reinstallation
+  if ip link show ${WG_IFACE} >/dev/null 2>&1; then
+    echo "Existing ${WG_IFACE} detected - removing old instance"
+    safe_systemctl stop wg-quick@${WG_IFACE} || true
+    wg-quick down ${WG_IFACE} || true
+    rm -f /etc/wireguard/${WG_IFACE}.conf
+  fi
   cat > /etc/wireguard/${WG_IFACE}.conf <<EOF
 [Interface]
 Address = ${VPN_IPV4}/26, ${WG_IPV6_BASE}::1/64


### PR DESCRIPTION
## Summary
- gracefully recreate the WireGuard interface on reinstall by shutting down any
  existing instance first

## Testing
- `shellcheck install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68611ab759c08322b057c050895e2fc0