### PR TITLE
Add loopback and DNS port rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,18 @@ Wir verfolgen folgende Hauptziele:
    * Landingpage: `http://10.66.66.1:80` (für abgelaufene Peers)
 3. Im CLI‑Menü Peers anlegen, Quotas prüfen und Blacklists verwalten.
 
+## Konfiguration
+
+Die Firewall erlaubt nun zusätzlich den Loopback‑Verkehr sowie Zugriffe auf die
+DNS‑Ports `5335` (Unbound) und `5353` (AdGuard). Die relevanten Regeln finden
+sich in `install.sh` innerhalb der Funktion `configure_nftables`:
+
+```nft
+oifname "lo" accept
+ip protocol udp udp dport {5335,5353} accept
+ip protocol tcp tcp dport {5335,5353} accept
+```
+
 ## Lizenz
 
 MIT © DeinName

--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,10 @@ table inet vpn {
 	ip protocol udp udp dport 53 accept
 	ip protocol tcp tcp dport 53 accept
 	# optional: HTTP/HTTPS für Updates o.Ä.
-	ip protocol tcp tcp dport {80,443} accept	
+	ip protocol tcp tcp dport {80,443} accept
+        oifname "lo" accept
+        ip protocol udp udp dport {5335,5353} accept
+        ip protocol tcp tcp dport {5335,5353} accept	
   }
 
   chain forward {


### PR DESCRIPTION
## Summary
- allow loopback traffic and DNS ports in nftables rules
- document firewall rule additions in README

## Testing
- `sudo nft -f /etc/nftables.conf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686818e391988322a9c3c2f6fb82b39c